### PR TITLE
Force the minimum numexpr version to be 2.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - msgpack-python
     - ndindex
     - py-cpuinfo
-    - numexpr
+    - numexpr >=2.12.1
     - numpy >=1.26.0
     - requests
     - platformdirs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8716254cd6ab5c6f5020650c05f73586e0e69dfc47397f688fac11ad2a0f84e5
 
 build:
-  number: 2
+  number: 3
   skip: true  # [py<311]
   script_env:
     - USE_SYSTEM_BLOSC2=1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
